### PR TITLE
Fix for avoiding mocking sealed types

### DIFF
--- a/bunit.AutoMocker.Tests/SealedTypesTests.cs
+++ b/bunit.AutoMocker.Tests/SealedTypesTests.cs
@@ -1,0 +1,20 @@
+using bunit.BlazorTestApp.Components;
+using Bunit.AutoMocker;
+
+namespace bunit.AutoMocker.Tests;
+
+public sealed class SealedTypesTests : AutoMockerTestBase
+{
+    [Fact]
+    public void WhenSealedDependencyIsNotHandledByAutoMocker_ThrowsInvalidOperationException()
+    {
+        // Arrange
+        var sut = new AutoMockerServiceProvider(Mocker);
+
+        // Act
+        var result = sut.GetService(typeof(MySealedDependency));
+
+        // Assert
+        Assert.Null(result);
+    }
+}

--- a/bunit.AutoMocker/AutoMockerServiceProvider.cs
+++ b/bunit.AutoMocker/AutoMockerServiceProvider.cs
@@ -11,6 +11,10 @@ public class AutoMockerServiceProvider(Moq.AutoMock.AutoMocker mocker, params Ty
 
     public object? GetService(Type serviceType)
     {
+        // Never attempt to mock sealed classes
+        if (serviceType.IsSealed)
+            return null;
+
         return _typesToExclude.Contains(serviceType) 
             ? null 
             : _mocker.Get(serviceType);

--- a/bunit.BlazorTestApp/Components/MySealedDependency.cs
+++ b/bunit.BlazorTestApp/Components/MySealedDependency.cs
@@ -1,0 +1,5 @@
+﻿namespace bunit.BlazorTestApp.Components;
+
+public sealed class MySealedDependency
+{
+}


### PR DESCRIPTION
When upgrading from .NET 8 to .NET 10  I ran into the issue where the runtime is trying to resolve some types that are sealed. This may also be the case in .NET 9, but I didn't test that. Because these types also internal it's not possible to add them to the exclusion list. The fix is simple though: do not try to mock sealed types.